### PR TITLE
Correct method name of deleting load balancer method

### DIFF
--- a/network/aws-elb.js
+++ b/network/aws-elb.js
@@ -46,7 +46,7 @@ class ELB {
     checkParams(params);
 
     return new Promise((resolve, reject) => {
-      this._elb.deleteLoadBalancerListeners(params, (err, data) => {
+      this._elb.deleteLoadBalancer(params, (err, data) => {
         if (err) {
           reject(err);
         } else {

--- a/network/aws-route53.js
+++ b/network/aws-route53.js
@@ -65,7 +65,7 @@ class Route53 {
     checkParams(params);
     // list zones
     return new Promise((resolve, reject) => {
-      this._route53.listHostedZone(params, (err, data) => {
+      this._route53.listHostedZones(params, (err, data) => {
         if (err) {
           reject(err);
         } else {


### PR DESCRIPTION
Change  delete method's AWS SDK API call method `fromdeleteLoadBalancerListeners` to `deleteLoadBalancer`