### PR TITLE
Adding instance monitor management for EC2

### DIFF
--- a/compute/aws-ec2.js
+++ b/compute/aws-ec2.js
@@ -105,6 +105,54 @@ class EC2 {
   }
 
   /**
+   * Start instance monitoring
+   * @monitor
+   * @param {object} params
+   */
+  monitor(params) {
+    return new Promise((resolve, reject) => {
+      this._ec2.monitorInstances(params, function(err, data) {
+        if (err && err.code === 'DryRunOperation') {
+          params.DryRun = false;
+          this._ec2.monitorInstances(params, function(err, data) {
+              if (err) {
+                reject(err);
+              } else if (data) {
+                resolve(data);
+              }
+          });
+        } else {
+          reject('Permission denied');
+        }
+      });
+    });
+  }
+
+  /**
+   * Stop instance monitoring
+   * @unmonitor
+   * @param {object} params
+   */
+  unmonitor(params) {
+    return new Promise((resolve, reject) => {
+      this._ec2.unmonitorInstances(params, function(err, data) {
+        if (err && err.code === 'DryRunOperation') {
+          params.DryRun = false;
+          this._ec2.unmonitorInstances(params, function(err, data) {
+              if (err) {
+                reject(err);
+              } else if (data) {
+                resolve(data);
+              }
+          });
+        } else {
+          reject('Permission denied');
+        }
+      });
+    });
+  }
+
+  /**
    * Reboot instance
    * @reboot
    * @param {object} params

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nodecloud-aws-plugin",
-  "version": "1.0.0",
+  "version": "1.0.0-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Fixes - #9 
## Explanation
* This PR adds instance monitor management for EC2 which was developed referencing the AWS sdk [documentation](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/ec2-example-managing-instances.html).