### PR TITLE
Enhancement fix in ec2 stop function

### DIFF
--- a/compute/aws-ec2.js
+++ b/compute/aws-ec2.js
@@ -95,10 +95,15 @@ class EC2 {
   stop(params) {
     return new Promise((resolve, reject) => {
       this._ec2.stopInstances(params, (err, data) => {
-        if (err) {
-          reject(err);
-        } else if (data) {
-          resolve(data);
+        if (err && err.code === "DryRunOperation") {
+          params.DryRun = false;
+          this._ec2.stopInstances(params, (err, data) => {
+            if (err) {
+              reject(err);
+            } else if (data) {
+              resolve(data);
+            }
+          });
         }
       });
     });
@@ -111,10 +116,10 @@ class EC2 {
    */
   monitor(params) {
     return new Promise((resolve, reject) => {
-      this._ec2.monitorInstances(params, function(err, data) {
+      this._ec2.monitorInstances(params, function (err, data) {
         if (err && err.code === "DryRunOperation") {
           params.DryRun = false;
-          this._ec2.monitorInstances(params, function(err, data) {
+          this._ec2.monitorInstances(params, function (err, data) {
             if (err) {
               reject(err);
             } else if (data) {
@@ -137,10 +142,10 @@ class EC2 {
    */
   unmonitor(params) {
     return new Promise((resolve, reject) => {
-      this._ec2.unmonitorInstances(params, function(err, data) {
+      this._ec2.unmonitorInstances(params, function (err, data) {
         if (err && err.code === "DryRunOperation") {
           params.DryRun = false;
-          this._ec2.unmonitorInstances(params, function(err, data) {
+          this._ec2.unmonitorInstances(params, function (err, data) {
             if (err) {
               reject(err);
             } else if (data) {


### PR DESCRIPTION
* It is recommended to use the `DryRun` parameter to test  permission before actually attempting to start or stop the selected instances according to the AWS documentation.  It checks whether the required permissions for the action, without actually making the request, and provides an error response. If the required permissions are met, the error response is `DryRunOperation`.Afterwards the dry run parameter must set false in order to stop the instance. 
```
ec2.stopInstances(params, function(err, data) {
    if (err && err.code === 'DryRunOperation') {
      params.DryRun = false;
      ec2.stopInstances(params, function(err, data) {
          if (err) {
            console.log("Error", err);
          } else if (data) {
            console.log("Success", data.StoppingInstances);
          }
      }); 
```
References - 
* https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/ec2-example-managing-instances.html 
* https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/EC2.html#stopInstances-property