### PR TITLE
correcting the github CI failing issue

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -24,6 +24,7 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: ${{ matrix.node-version }}
+    - run: npm install mocha
     - run: npm test
       env:
         CI: true


### PR DESCRIPTION
fixes #15 

add run command to `install mocha` on the  job's virtual machine